### PR TITLE
Qtile package review

### DIFF
--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -21,11 +21,7 @@ BuildRequires:  gcc
 BuildRequires:  xorg-x11-server-Xvfb
 BuildRequires:  xorg-x11-server-Xephyr
 BuildRequires:  rsvg-pixbuf-loader
-BuildRequires:  pango-devel
-BuildRequires:  libxkbcommon-devel
 BuildRequires:  wlroots-devel
-BuildRequires:  gtk3-devel
-BuildRequires:  pulseaudio-libs-devel
 %if %{with wayland}
 BuildRequires:  xorg-x11-server-Xwayland
 %endif
@@ -38,7 +34,6 @@ BuildRequires:  xorg-x11-server-Xwayland
 %global libsymbolsuffix ()(%{__isa_bits}bit)
 %endif
 
-BuildRequires:  pango-devel
 BuildRequires: libgobject-2.0.so.0%{libsymbolsuffix}
 BuildRequires: libpango-1.0.so.0%{libsymbolsuffix}
 BuildRequires: libpangocairo-1.0.so.0%{libsymbolsuffix}
@@ -129,6 +124,7 @@ desktop-file-install \
 - Remove temporary python3-cairocffi dependencies
 - Remove duplicate %%pyproject_buildrequires
 - Buildrequire rsvg-pixbuf-loader for SVG image loading during the test suite
+- Remove unnecessary buildrequires
 
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch

--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -20,9 +20,8 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  gcc
 BuildRequires:  xorg-x11-server-Xvfb
 BuildRequires:  xorg-x11-server-Xephyr
+BuildRequires:  rsvg-pixbuf-loader
 BuildRequires:  pango-devel
-BuildRequires:  gdk-pixbuf2-devel
-BuildRequires:  librsvg2-devel
 BuildRequires:  libxkbcommon-devel
 BuildRequires:  wlroots-devel
 BuildRequires:  gtk3-devel
@@ -129,6 +128,7 @@ desktop-file-install \
 - Remove manual dependencies that duplicate generated ones
 - Remove temporary python3-cairocffi dependencies
 - Remove duplicate %%pyproject_buildrequires
+- Buildrequire rsvg-pixbuf-loader for SVG image loading during the test suite
 
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch

--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -14,7 +14,6 @@ License: MIT AND GPL-3.0-or-later
 Url: http://qtile.org
 
 BuildRequires:  python3-devel
-BuildRequires:  cairo
 BuildRequires:  desktop-file-utils
 
 # Test dependencies
@@ -47,19 +46,6 @@ BuildRequires: libpangocairo-1.0.so.0%{libsymbolsuffix}
 Requires: libgobject-2.0.so.0%{libsymbolsuffix}
 Requires: libpango-1.0.so.0%{libsymbolsuffix}
 Requires: libpangocairo-1.0.so.0%{libsymbolsuffix}
-
-# missing from python3-cairocffi
-BuildRequires: libgdk_pixbuf-2.0.so.0%{libsymbolsuffix}
-BuildRequires: libglib-2.0.so.0%{libsymbolsuffix}
-BuildRequires: libgdk-3.so.0%{libsymbolsuffix}
-
-# missing from python3-cairocffi
-Requires: libgdk_pixbuf-2.0.so.0%{libsymbolsuffix}
-Requires: libglib-2.0.so.0%{libsymbolsuffix}
-Requires: libgdk-3.so.0%{libsymbolsuffix}
-
-# python3-cairocffi is not currently pulling in cairo
-Requires:  cairo
 
 # Recommended packages for widgets
 Recommends: python3-psutil
@@ -140,6 +126,7 @@ desktop-file-install \
 %changelog
 * Fri Nov 10 2023 Carl George <carlwgeorge@fedoraproject.org> - 0.23.0-3
 - Remove manual dependencies that duplicate generated ones
+- Remove temporary python3-cairocffi dependencies
 
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch

--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -51,8 +51,9 @@ Recommends: python3-mpd2
 
 %if %{with wayland}
 # Wayland-specific dependencies
-Recommends: python3-pywayland
-Recommends: python3-pywlroots >= 0.16
+Recommends: python3-pywayland >= 0.4.14
+Recommends: python3-xkbcommon >= 0.3
+Recommends: python3-pywlroots >= 0.16.4
 %endif
 
 
@@ -125,6 +126,7 @@ desktop-file-install \
 - Remove duplicate %%pyproject_buildrequires
 - Buildrequire rsvg-pixbuf-loader for SVG image loading during the test suite
 - Remove unnecessary buildrequires
+- Correct wayland recommends
 
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch

--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -2,7 +2,7 @@
 
 Name: qtile
 Version: 0.23.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: A pure-Python tiling window manager
 Source: https://github.com/qtile/qtile/archive/v%{version}/qtile-%{version}.tar.gz
 
@@ -14,15 +14,7 @@ License: MIT AND GPL-3.0-or-later
 Url: http://qtile.org
 
 BuildRequires:  python3-devel
-BuildRequires:  python3-setuptools
-BuildRequires:  python3-cffi
-BuildRequires:  python3-xcffib >= 1.4.0
-BuildRequires:  python3-cairocffi >= 1.6.0
 BuildRequires:  cairo
-BuildRequires:  python3-six
-BuildRequires:  python3-pycparser
-BuildRequires:  python3-setuptools_scm
-BuildRequires:  python3-dbus-next
 BuildRequires:  desktop-file-utils
 
 # Test dependencies
@@ -35,9 +27,6 @@ BuildRequires:  librsvg2-devel
 BuildRequires:  libxkbcommon-devel
 BuildRequires:  wlroots-devel
 BuildRequires:  gtk3-devel
-BuildRequires:  python3-pytest
-BuildRequires:  python3-bowler
-BuildRequires:  python3-gobject
 BuildRequires:  pulseaudio-libs-devel
 %if %{with wayland}
 BuildRequires:  xorg-x11-server-Xwayland
@@ -64,17 +53,11 @@ BuildRequires: libgdk_pixbuf-2.0.so.0%{libsymbolsuffix}
 BuildRequires: libglib-2.0.so.0%{libsymbolsuffix}
 BuildRequires: libgdk-3.so.0%{libsymbolsuffix}
 
-BuildRequires: python3-xcffib
-
 # missing from python3-cairocffi
 Requires: libgdk_pixbuf-2.0.so.0%{libsymbolsuffix}
 Requires: libglib-2.0.so.0%{libsymbolsuffix}
 Requires: libgdk-3.so.0%{libsymbolsuffix}
 
-Requires:  python3-cairocffi
-Requires:  python3-cffi
-Requires:  python3-xcffib
-Requires:  python3-dbus-next
 # python3-cairocffi is not currently pulling in cairo
 Requires:  cairo
 
@@ -155,6 +138,9 @@ desktop-file-install \
 
 
 %changelog
+* Fri Nov 10 2023 Carl George <carlwgeorge@fedoraproject.org> - 0.23.0-3
+- Remove manual dependencies that duplicate generated ones
+
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch
 - Only optional dependency on xorg-x11-server-Xwayland

--- a/SPECS/qtile-f39.spec
+++ b/SPECS/qtile-f39.spec
@@ -81,10 +81,11 @@ Features
 
 %prep
 %autosetup -p 1
+
+
 %generate_buildrequires
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
-%pyproject_buildrequires %{?with_wayland:-x wayland}
-%pyproject_buildrequires -x test
+%pyproject_buildrequires -x test %{?with_wayland:-x wayland}
 
 
 %build
@@ -127,6 +128,7 @@ desktop-file-install \
 * Fri Nov 10 2023 Carl George <carlwgeorge@fedoraproject.org> - 0.23.0-3
 - Remove manual dependencies that duplicate generated ones
 - Remove temporary python3-cairocffi dependencies
+- Remove duplicate %%pyproject_buildrequires
 
 * Sat Nov 04 2023 Jakub Kadlcik <frostyx@email.cz> - 0.23.0-2
 - Remove noarch


### PR DESCRIPTION
- Remove manual dependencies that duplicate generated ones
- Remove temporary python3-cairocffi dependencies
- Remove duplicate %pyproject_buildrequires
- Buildrequire rsvg-pixbuf-loader for SVG image loading during the test suite
- Remove unnecessary buildrequires
- Correct wayland recommends